### PR TITLE
Use catch2 in header only mode to save build time.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Cache CMake build
+      - name: Cache Catch2
         uses: actions/cache@v4
         with:
           path: build/_deps
-          key: ${{ runner.os }}-catch2-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-catch2-
+          key: ${{ runner.os }}-catch2-v3.5.2
 
       - name: Set up CMake
         uses: lukka/get-cmake@latest

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,11 +6,13 @@ FetchContent_Declare(
   GIT_TAG v3.5.2
 )
 
-# catsc2 takes forewer to build
-set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+set(CATCH2_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+set(CATCH2_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(CATCH2_BUILD_EXTRA_TESTS OFF CACHE BOOL "" FORCE)
+set(CATCH2_BUILD_HEADER_ONLY ON CACHE BOOL "" FORCE)
+
 FetchContent_MakeAvailable(catch2)
 
-# cross‑platform tests
 add_executable(test_filetree test_filetree.cpp)
 target_link_libraries(test_filetree
     PRIVATE


### PR DESCRIPTION
## Description
Updated catch2 to run in header mode. This should shorten down on build time for GitHub actions.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update

## Checklist
- [x] My code builds and runs locally
- [ ] I have added tests that prove my fix/feature works
- [x] All tests pass with `ctest --output-on-failure`
- [ ] I have updated documentation if necessary

## Related Issues
Link to any related issues or discussions.
